### PR TITLE
fix: memcached deployment

### DIFF
--- a/templates/memcached-deployment.yaml
+++ b/templates/memcached-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       - command:
         - memcached
         - -m
-        - {{ .Values.memcached.size }}
+        - "{{ .Values.memcached.size }}"
         image: memcached:1.5.6
         imagePullPolicy: ""
         name: seatable-memcached


### PR DESCRIPTION
The  error was :` Error: INSTALLATION FAILED: Deployment in version "v1" cannot be handled as a Deployment: json: cannot unmarshal number into Go struct field Container.spec .template.spec.containers.command of type string`